### PR TITLE
Fix input in games

### DIFF
--- a/game.libretro.gambatte/addon.xml.in
+++ b/game.libretro.gambatte/addon.xml.in
@@ -5,7 +5,7 @@
 		provider-name="Libretro">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
-		<import addon="game.controller.gba" version="1.0.0"/>
+		<import addon="game.controller.gameboy" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">


### PR DESCRIPTION
Gambatte was expecting Game Boy input but was receiving (and ignoring) Game Boy Advance input.

Tested on OSX, input works after mapping the Game Boy controller.